### PR TITLE
Add a buffer to deleted tracking codes before hard deleting

### DIFF
--- a/src/libraries/Gaspra.SqlGenerator/Factories/Sections/Procedure/RetentionSection.cs
+++ b/src/libraries/Gaspra.SqlGenerator/Factories/Sections/Procedure/RetentionSection.cs
@@ -25,7 +25,12 @@ namespace Gaspra.SqlGenerator.Factories.Sections.Procedure
         {
             var mergeStatement = new List<string>
             {
-                $"WHEN NOT MATCHED BY SOURCE AND t.{variableSet.RetentionPolicy.ComparisonColumn} < DATEADD(MONTH, -{variableSet.RetentionPolicy.RetentionMonths}, GETUTCDATE())",
+                $"WHEN NOT MATCHED BY SOURCE AND t.[{variableSet.RetentionPolicy.ComparisonColumn}] < DATEADD(MONTH, -{variableSet.RetentionPolicy.RetentionMonths}, GETUTCDATE()) AND t.[Deleted] IS NULL",
+                "    THEN UPDATE SET",
+                "        t.[Deleted]= GETUTCDATE()",
+                "",
+
+                $"WHEN NOT MATCHED BY SOURCE AND t.[{variableSet.RetentionPolicy.ComparisonColumn}] < DATEADD(DAY, -3, DATEADD(MONTH, -{variableSet.RetentionPolicy.RetentionMonths}, GETUTCDATE()))",
                 "    THEN DELETE"
             };
 


### PR DESCRIPTION
As tracking code records were getting hard deleted immediately, we cant use the record to get the OrderFactId. This means we have no way of identifying those records. We should mark the rows as soft deleted and hard delete them x (3) days later