### PR TITLE
Change the delta scripts to use include rather than exclude

### DIFF
--- a/src/libraries/Gaspra.SqlGenerator/Factories/Sections/Delta/AboutSection.cs
+++ b/src/libraries/Gaspra.SqlGenerator/Factories/Sections/Delta/AboutSection.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Gaspra.Database.Extensions;
 using Gaspra.SqlGenerator.Interfaces;
 using Gaspra.SqlGenerator.Models;
 
@@ -33,13 +31,13 @@ namespace Gaspra.SqlGenerator.Factories.Sections.Delta
                 $" **",
                 $" ** About:",
                 $" **     Retrieve the identifiers for any data points changed (inserted, updated, deleted)",
-                $" **     over a given period of time. Use the ignore parameter table type to ignore specific",
+                $" **     over a given period of time. Use the include parameter table type to include specific",
                 $" **     tables when looking at the changed identifiers.",
                 $" **",
                 $" ** Parameters:",
                 $" **     @Delta [DATETIME],",
                 $" **     @{variableSet.TableTypeVariableName} [{variableSet.Schema.Name}].[{variableSet.TableTypeName}] (",
-                $" **         [Ignore] NVARCHAR(50) NOT NULL",
+                $" **         [Include] NVARCHAR(50) NOT NULL",
                 $" **     )",
                 $" **",
                 $" ** Tables covered by delta:"
@@ -92,7 +90,7 @@ namespace Gaspra.SqlGenerator.Factories.Sections.Delta
                     }
                     else
                     {
-                        return " " + new string('*', longestLine + 2 );
+                        return " " + new string('*', longestLine + 2);
                     }
                 }));
 

--- a/src/libraries/Gaspra.SqlGenerator/Factories/Sections/Delta/Procedure/AlterProcedureSection.cs
+++ b/src/libraries/Gaspra.SqlGenerator/Factories/Sections/Delta/Procedure/AlterProcedureSection.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Gaspra.Database.Extensions;
@@ -42,7 +41,7 @@ namespace Gaspra.SqlGenerator.Factories.Sections.Delta.Procedure
 
                 var selectStatement = new List<string>
                 {
-                    $"IF NOT EXISTS (SELECT 1 FROM @{variableSet.TableTypeVariableName} WHERE Ignore='{rootTable.Name}')",
+                    $"IF EXISTS (SELECT 1 FROM @{variableSet.TableTypeVariableName} WHERE Include='{rootTable.Name}')",
                     $"BEGIN",
                     $"    INSERT INTO",
                     $"        @{variableSet.DomainIdentifierName}",
@@ -50,8 +49,8 @@ namespace Gaspra.SqlGenerator.Factories.Sections.Delta.Procedure
                 };
 
                 selectStatement.AddRange(from selectColumn in selectColumns
-                    let lastColumn = selectColumns.Last().Equals(selectColumn) ? "" : ","
-                    select $"        {targetTable.Name}.{selectColumn.Name}{lastColumn}");
+                                         let lastColumn = selectColumns.Last().Equals(selectColumn) ? "" : ","
+                                         select $"        {targetTable.Name}.{selectColumn.Name}{lastColumn}");
 
                 selectStatement.Add($"    FROM");
 
@@ -113,8 +112,8 @@ namespace Gaspra.SqlGenerator.Factories.Sections.Delta.Procedure
             });
 
             script.AddRange(from selectColumn in selectColumns
-                let lastColumn = selectColumns.Last().Equals(selectColumn) ? "" : ","
-                select $"    {selectColumn.Name}{lastColumn}");
+                            let lastColumn = selectColumns.Last().Equals(selectColumn) ? "" : ","
+                            select $"    {selectColumn.Name}{lastColumn}");
 
             script.AddRange(new List<string>
             {

--- a/src/libraries/Gaspra.SqlGenerator/Services/DeltaScriptGenerator.cs
+++ b/src/libraries/Gaspra.SqlGenerator/Services/DeltaScriptGenerator.cs
@@ -79,7 +79,7 @@ namespace Gaspra.SqlGenerator.Services
                         HistoryTable = table.Properties.First(p => p.Key.Equals("gf.Record")).Value,
                         RootPath = table.PathToRoot()
                     })
-                    .GroupBy(t => "Delta" + t.RootPath?.Last()?.Name + "From" + t.HistoryTable )
+                    .GroupBy(t => "Delta" + t.RootPath?.Last()?.Name + "From" + t.HistoryTable)
                     .ToList();
 
                 foreach (var tableGroup in tableHistoryInformationList)
@@ -94,17 +94,17 @@ namespace Gaspra.SqlGenerator.Services
                         ScriptName = $"{tableGroup.Key}",
                         Schema = schema,
                         Table = null,
-                        TableTypeName = $"TT_{tableGroup.Key}Ignore",
+                        TableTypeName = $"TT_{tableGroup.Key}Include",
                         TableTypeColumns = new List<ColumnModel>
                         {
                             new ColumnModel()
                             {
-                                Name = "Ignore",
+                                Name = "Include",
                                 DataType = "NVARCHAR",
                                 MaxLength = 50
                             }
                         },
-                        TableTypeVariableName = $"{tableGroup.Key}Ignore",
+                        TableTypeVariableName = $"{tableGroup.Key}Include",
                         DomainIdentifierName = domainIdentifierColumn.Name,
                         TablePaths = pathsToRoot,
                         DeltaSourceTableName = tableGroup.First().HistoryTable


### PR DESCRIPTION
Changing the TT on the delta scripts to include rather than exclude. If new tables are added and the delta scripts regenerated, we would need to exclude the new tables wherever the sprocs are called.